### PR TITLE
Fix mod_wsgi installation on Debian

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,10 @@ source venv/bin/activate
 echo "Upgrading pip..."
 pip install --upgrade pip
 
+# Remove mod_wsgi if it's in requirements.txt
+echo "Updating requirements.txt..."
+sed -i '/mod_wsgi/d' requirements.txt
+
 # Install Python dependencies
 echo "Installing Python dependencies..."
 pip install -r requirements.txt


### PR DESCRIPTION
- Add command to remove mod_wsgi from requirements.txt if present
- Rely solely on libapache2-mod-wsgi-py3 package instead of pip version